### PR TITLE
Add ability to play C8 and beyond

### DIFF
--- a/src/PlayRtttl.hpp
+++ b/src/PlayRtttl.hpp
@@ -422,10 +422,16 @@ bool updatePlayRtttl(void) {
 #endif
         if (tNote <= 12) {
 #if defined(__AVR__)
-            uint16_t tFrequency = pgm_read_word(&Notes[tNote]) >> (NOTES_OCTAVE - tOctave);
+            uint16_t tFrequency = pgm_read_word(&Notes[tNote]);
 #else
-            uint16_t tFrequency = Notes[tNote] >> (NOTES_OCTAVE - tOctave);
+            uint16_t tFrequency = Notes[tNote];
 #endif // defined(__AVR__)
+            if (tOctave <= NOTES_OCTAVE) {
+                tFrequency >>= (NOTES_OCTAVE - tOctave);
+            } else {
+                tFrequency <<= (tOctave - NOTES_OCTAVE);
+            }
+
 
 #if defined(ESP32)
             ledcWriteTone(TONE_LEDC_CHANNEL, tFrequency);


### PR DESCRIPTION
I recently attempted to play a song that included C8 and realized this library didn't support notes that high. Here is a simple pull request that allows C8 and also theoretically any notes in that octave and beyond.